### PR TITLE
configure.ac: enable AC_SYS_LARGEFILE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,8 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_LANG([C])
 AC_USE_SYSTEM_EXTENSIONS
+# Make sure we use 64-bit file API on 32-bit systems.
+AC_SYS_LARGEFILE
 
 # Checks for libraries.
 if test "$which_cv_iberty" = yes ; then


### PR DESCRIPTION
Without the change `which` fails to find programs on filesystems with 64-bit inodes when `which` itself is 32-bit.

In my case it is `btrfs` and `i686-unknown-linux-gnu`.

`bison` is in the PATH:

    $ dev>bison
    bison: missing operand
    Try 'bison --help' for more information.

But `which` fails to find it:

    $ dev>which bison
    which: no bison in ...

`bison` is a file with an inode number that overflows 2^31 limit:

    $ stat ~/bin/bison
      File: ~/bin/bison
      Size: 674260          Blocks: 1320       IO Block: 4096   regular file
    Device: 0,29    Inode: 4384368825  Links: 2
    Access: (0555/-r-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
    Access: 2023-09-05 04:48:43.000000000 +0100
    Modify: 1970-01-01 01:00:01.000000000 +0100
    Change: 2023-09-05 04:48:43.821566578 +0100
     Birth: 2023-09-05 04:48:43.772565733 +0100

The change fixes `which` run.